### PR TITLE
docs: quote pip extras install examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Alternatively, you can clone this repository, enter the directory and run:
 If you are a developer, you might want to also install the optional development
 dependencies by running
 ```console
-> python -m pip install .[dev]
+> python -m pip install '.[dev]'
 ```
 instead.
 


### PR DESCRIPTION
## Summary
- Quote `pip install` examples that include extras.

## Why
- Shells such as zsh can expand unquoted bracket expressions before `pip` receives them.

## Scope
- Files changed:
- `README.md`
- This does not change dependencies or runtime behavior.

## Testing
- `git diff --check`

## Maintainer Fit
- Small install-command correctness fix.
- Duplicate PR search terms checked: `quote pip extras`, `quote optional dependency`, `zsh pip install extras`, `pip extras install examples`