### PR TITLE
Stabilize alignment rotations near antiparallel vectors

### DIFF
--- a/e3x/so3/rotations.py
+++ b/e3x/so3/rotations.py
@@ -100,7 +100,7 @@ def alignment_rotation(
   :math:`\vec{u}` with the vector :math:`\vec{v}` using the shortest possible
   arc. When :math:`\vec{u}` and :math:`\vec{v}` are exactly antiparallel, there
   are infinitely many paths with the same arc length and one of them is chosen
-  at random.
+  deterministically.
 
   Example:
     >>> import jax.numpy as jnp
@@ -121,24 +121,31 @@ def alignment_rotation(
   u = ops.normalize(u, axis=-1)
   v = ops.normalize(v, axis=-1)
 
+  dot = jnp.sum(u * v, axis=-1)
+  mask = dot >= 0
+  # u x (u + v) equals u x v, but avoids cancellation near antiparallel.
+  x = jnp.cross(u, jnp.where(mask[..., None], v, u + v))
   # Create the skew-symmetric cross product matrix.
-  x = jnp.cross(u, v)  # Cross product vector.
   zeros = jnp.zeros_like(x[..., 0:1])
   col1 = jnp.concatenate((zeros, -x[..., 2:3], x[..., 1:2]), axis=-1)
   col2 = jnp.concatenate((x[..., 2:3], zeros, -x[..., 0:1]), axis=-1)
   col3 = jnp.concatenate((-x[..., 1:2], x[..., 0:1], zeros), axis=-1)
   skew = jnp.stack((col1, col2, col3), axis=-1)
 
-  # Calculate rotation matrix (does not handle antiparallel case correctly).
-  div = 1 + jnp.sum(u * v, axis=-1)
-  mask = div > 0
-  safe_div = jnp.where(mask, div, 1)
+  # The direct formula is well-conditioned for non-obtuse angles.
+  safe_div = jnp.where(mask, 1 + dot, 1)
   rot = skew + skew @ skew * (1 / safe_div)[..., None, None] + jnp.eye(3)
 
-  # Handle antiparallel case.
-  w = ops.normalize(u + jnp.roll(u, shift=1, axis=-1))
-  axis = jnp.cross(u, w)
-  rot = jnp.where(mask[..., None, None], rot, rotation(axis, jnp.pi))  # pyrefly: ignore[bad-argument-type]
+  # For obtuse angles, avoid cancellation in 1 + dot. At antiparallel
+  # inputs the cross product vanishes, so choose a guaranteed perpendicular
+  # axis using the coordinate direction least aligned with u.
+  cross_norm = ops.norm(x, axis=-1)
+  basis = jax.nn.one_hot(jnp.argmin(jnp.abs(u), axis=-1), 3, dtype=u.dtype)
+  axis = jnp.where(
+      (cross_norm > jnp.finfo(u.dtype).eps)[..., None], x, jnp.cross(u, basis)
+  )
+  angle = jnp.arctan2(cross_norm, dot)
+  rot = jnp.where(mask[..., None, None], rot, rotation(axis, angle))
 
   return rot
 

--- a/tests/so3/rotations_test.py
+++ b/tests/so3/rotations_test.py
@@ -18,6 +18,7 @@ from ..testing import subtests
 import jax
 import jax.numpy as jnp
 import jaxtyping
+import numpy as np
 import pytest
 
 Array = jaxtyping.Array
@@ -175,6 +176,49 @@ def test_alignment_rotation(
       e3x.ops.norm(us, axis=-1) * e3x.ops.norm(v, axis=-1)
   )
   assert jnp.allclose(cos, 1.0, atol=1e-5)
+
+
+@pytest.mark.parametrize('compiled', [False, True])
+@pytest.mark.parametrize('offset', [0.0, 1e-4, 1e-2])
+def test_alignment_rotation_near_antiparallel(compiled, offset):
+  # Include symmetric diagonals for which rolling u cannot give a new axis.
+  u = np.array([
+      [1., 1., 1.], [-1., -1., -1.], [1., 0., 0.],
+      [0., 1., 0.], [0., 0., -1.], [1., -2., 3.],
+  ], dtype=np.float32)
+  v = -u + offset * np.roll(u, 1, axis=-1)
+  u /= np.linalg.norm(u, axis=-1, keepdims=True)
+  v /= np.linalg.norm(v, axis=-1, keepdims=True)
+  align = e3x.so3.alignment_rotation
+  if compiled:
+    align = jax.jit(align)
+  rot = np.asarray(align(jnp.asarray(u), jnp.asarray(v)))
+  np.testing.assert_allclose(
+      np.einsum('...i,...ij->...j', u, rot), v, atol=2e-6)
+  np.testing.assert_allclose(
+      rot @ np.swapaxes(rot, -1, -2),
+      np.broadcast_to(np.eye(3), rot.shape), atol=2e-6)
+  np.testing.assert_allclose(np.linalg.det(rot), 1., atol=2e-6)
+
+
+def test_alignment_rotation_antiparallel_single_matches_batch():
+  u = jnp.asarray([1., 1., 1.])
+  rot = e3x.so3.alignment_rotation(u, -u)
+  np.testing.assert_allclose(u @ rot, -u, atol=2e-6)
+  batch_u = jnp.stack([u, jnp.asarray([1., -2., 3.])])
+  batch_rot = e3x.so3.alignment_rotation(batch_u, -batch_u)
+  np.testing.assert_allclose(rot, batch_rot[0], atol=2e-6)
+
+
+@pytest.mark.parametrize('v', [[1., 0., 0.], [1., 2., 3.], [-1., 2., 3.]])
+def test_alignment_rotation_gradients_are_finite(v):
+  u, v = jnp.asarray([1., 0., 0.]), jnp.asarray(v)
+  fn = e3x.so3.alignment_rotation
+  tangent = jnp.ones(3)
+  _, jvp = jax.jvp(fn, (u, v), (tangent, tangent))
+  _, pullback = jax.vjp(fn, u, v)
+  assert jnp.all(jnp.isfinite(jvp))
+  assert all(jnp.all(jnp.isfinite(g)) for g in pullback(jnp.ones((3, 3))))
 
 
 @pytest.fixture(name='random_vectors')


### PR DESCRIPTION
`alignment_rotation` can return identity for opposite diagonal vectors such as `[1, 1, 1]` and `[-1, -1, -1]`. Near-antiparallel inputs also lose accuracy through cancellation in the cross product and `1 + dot`.

Keep the direct formula for non-obtuse angles and use a stable axis-angle construction for obtuse angles. Choose a deterministic perpendicular axis when the cross product vanishes.

Adds eager/JIT regressions for exact and near-antiparallel inputs, single/batched consistency, and gradient-finiteness controls. Seven regression cases fail on unchanged upstream.

Validation:
- `python -m pytest -q tests/so3/rotations_test.py tests/ops`: 230 passed.
- 4,000 float32/float64 vector-pair checks for alignment, orthogonality and determinant.
- Forward/reverse gradients checked against finite differences.
- Syntax compilation and `git diff --check` pass.
